### PR TITLE
Fix overlapping types

### DIFF
--- a/addons/structs/struct.gd
+++ b/addons/structs/struct.gd
@@ -66,16 +66,18 @@ class_name Struct extends Resource
 ##
 ## @experimental
 
+const TYPE_64BIT = (1<<6)
+
 ## Valid data types the Struct class is built to handle.
 enum DataType {
     ## Same as [enum Variant.Type.TYPE_STRING]
     TypeString = TYPE_STRING,
     ## Same as [enum Variant.Type.TYPE_INT]
-    TypeInt64 = TYPE_INT,
-    TypeInt32 = TYPE_INT*10,
+    TypeInt64 = TYPE_INT | TYPE_64BIT,
+    TypeInt32 = TYPE_INT,
     ## Same as [enum Variant.Type.TYPE_FLOAT]
-    TypeFloat64 = TYPE_FLOAT,
-    TypeFloat32 = TYPE_FLOAT*10,
+    TypeFloat64 = TYPE_FLOAT | TYPE_64BIT,
+    TypeFloat32 = TYPE_FLOAT,
     ## Same as [enum Variant.Type.TYPE_VECTOR2]
     TypeVector2 = TYPE_VECTOR2,
     ## Same as [enum Variant.Type.TYPE_VECTOR3]


### PR DESCRIPTION
I noticed that in Godot 4.x, DataType.TypeInt32 and DataType.TypeColor both equal 20

To resolve this, I just reserve the 7th LSB to indicate the difference in data length size. Considering that bit represents 64 (2<sup>6</sup>) in value, felt it made sense to "flag" the 64bit type with it rather than the 32bit type. In Godot 4, the max value today for any given type is 39, so that bit should remain untouched.

I chose to define the constant with a bitshift just to show clearly the intention behind that "magic number"